### PR TITLE
Add custom footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ A [Hugo](https://gohugo.io/)-theme based on [Simple.css](https://simplecss.org/)
 - SEO friendly 🔍
 - Beautiful code highlighting 😻 (thanks [catppuccin/catppuccin](https://github.com/catppuccin/catppuccin))
 
+## Customisation
+
+The theme provides partials for customising the `<head>`, `<body>` and `<footer>` of every page. Just copy and paste the partials from the theme to your local `layouts/partials/` folder.
+
 ## Demo Site
 
 [![screenshot](https://raw.githubusercontent.com/maolonglong/hugo-simple/main/images/tn.png)](https://maolonglong.github.io/hugo-simple/)

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -49,6 +49,7 @@
       {{ block "main" . }}{{ end }}
     </main>
     <footer>
+      {{ partial "custom_footer.html" . }}
       {{ partial "footer.html" . }}
     </footer>
 

--- a/layouts/partials/custom_footer.html
+++ b/layouts/partials/custom_footer.html
@@ -1,0 +1,3 @@
+<!-- A partial to be overwritten by the user.
+  Simply place a custom_footer.html into
+  your local /layouts/partials-directory -->


### PR DESCRIPTION
This PR adds a custom footer to every page in the site. For example, it can be used to add a secondary menu, point to a license, disclaimer or other legal information. Or all of that.