### PR TITLE
Support for lang

### DIFF
--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ .Params.lang | default .Site.LanguageCode | default "en" }}">
+<html lang="{{ .Params.lang | default .Lang | default "en" }}">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ with .Site.LanguageCode }}{{ . }}{{ else }}en{{ end }}">
+<html lang="{{ .Params.lang | default .Site.LanguageCode | default "en" }}">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
Add support for the front matter parameter `lang`. This can be useful if you occasionally need to tell the browser that a specific page is not written in the default language of the site. I usually write in English, but occasionally in Dutch. Specifying the html lang attributes helps browsers with properly translating pages.