### PR TITLE
fix(rss): remove deprecated author fallback

### DIFF
--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -1,4 +1,3 @@
-{{- /* Deprecate site.Author.email in favor of site.Params.author.email */}}
 {{- $authorEmail := "" }}
 {{- with site.Params.author }}
   {{- if reflect.IsMap . }}
@@ -6,14 +5,8 @@
       {{- $authorEmail = . }}
     {{- end }}
   {{- end }}
-{{- else }}
-  {{- with site.Author.email }}
-    {{- $authorEmail = . }}
-    {{- warnf "The author key in site configuration is deprecated. Use params.author.email instead." }}
-  {{- end }}
 {{- end }}
 
-{{- /* Deprecate site.Author.name in favor of site.Params.author.name */}}
 {{- $authorName := "" }}
 {{- with site.Params.author }}
   {{- if reflect.IsMap . }}
@@ -22,11 +15,6 @@
     {{- end }}
   {{- else }}
     {{- $authorName  = . }}
-  {{- end }}
-{{- else }}
-  {{- with site.Author.name }}
-    {{- $authorName = . }}
-    {{- warnf "The author key in site configuration is deprecated. Use params.author.name instead." }}
   {{- end }}
 {{- end }}
 


### PR DESCRIPTION
## What changed

- Removed the `site.Author.email` and `site.Author.name` fallback paths from `layouts/rss.xml`.
- Kept RSS author metadata sourced from `site.Params.author`, matching Hugo's current built-in RSS template behavior.

## Why

Fixes #74. When `[params.author]` is unset, the old fallback tries to access `site.Author`, which is no longer available in recent Hugo versions and causes RSS rendering to fail.

## Validation

- `bun run check`
- `hugo --source exampleSite --themesDir /Users/bytedance/projects --destination /tmp/hugo-simple-current-public`
- Temporary config with `[params.author]` removed builds successfully with `hugo --source exampleSite --themesDir /Users/bytedance/projects --config <tmp_config> --destination /tmp/hugo-simple-no-author-public`
